### PR TITLE
Set aspect to equal and correct axes labels

### DIFF
--- a/geonomics/structs/species.py
+++ b/geonomics/structs/species.py
@@ -1680,13 +1680,16 @@ class Species(OD):
 
                 #EVERYTHING BELOW THIS LINE IN THE LOOP IS JUST PLOT FORMATTING 
                 
-                label = ax.set_xlabel('CCA' + str(cc_axis1), fontsize = 9)
-                ax.xaxis.set_label_coords(0.5, -0.02)
-                label = ax.set_ylabel('CCA' + str(cc_axis2), fontsize = 9)
+                #note because the plot using center axis (intersect at 0):
+                #xlabel is the label at the bottom (vertical axis label) and ylabel is on the left side (horizontal axis label)
+                label = ax.set_ylabel('CCA' + str(cc1), fontsize = 9)
                 ax.yaxis.set_label_coords(-0.02, 0.55)
+                label = ax.set_xlabel('CCA' + str(cc2), fontsize = 9)
+                ax.xaxis.set_label_coords(0.5, -0.02)
 
                 #make into box
-                #ax.set_aspect('equal', adjustable='box')
+                ax.set_aspect('equal', adjustable='box')
+                
                 #Move left y-axis and bottom x-axis to center, passing through (0,0)
                 ax.spines['left'].set_position('center')
                 ax.spines['bottom'].set_position('center')


### PR DESCRIPTION
I uncommented the set_aspect() line such that the axis are equal (creates a square plot since the max/min of the axes are fixed). I also switched the axes labels because they were flipped. 